### PR TITLE
feat: Add GitHub Actions workflow to build and release firmware

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,56 @@
+name: Build and Release Firmware
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Install ARM GCC toolchain
+        uses: fiam/arm-none-eabi-gcc@v1
+        with:
+          release: '9-2019-q4-major'
+
+      - name: Build firmware
+        run: |
+          cd SW4STM/Debug
+          make
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.run_number }}
+          release_name: Release ${{ github.run_number }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: SW4STM/Debug/canfilter.hex
+          asset_name: canfilter.hex
+          asset_content_type: application/octet-stream
+
+      - name: Upload Release Asset
+        id: upload-release-asset-elf
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: SW4STM/Debug/canfilter.elf
+          asset_name: canfilter.elf
+          asset_content_type: application/octet-stream

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: Build and Release Firmware
 
 on:
   push:
-    branches:
-      - master
 
 jobs:
   build-and-release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install ARM GCC toolchain
         uses: fiam/arm-none-eabi-gcc@v1
         with:
-          release: '9-2019-q4-major'
+          release: '9-2019-q4'
 
       - name: Build firmware
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,35 +22,10 @@ jobs:
           cd SW4STM/Debug
           make
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.run_number }}
-          release_name: Release ${{ github.run_number }}
-          draft: false
-          prerelease: false
-
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: SW4STM/Debug/canfilter.hex
-          asset_name: canfilter.hex
-          asset_content_type: application/octet-stream
-
-      - name: Upload Release Asset
-        id: upload-release-asset-elf
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: SW4STM/Debug/canfilter.elf
-          asset_name: canfilter.elf
-          asset_content_type: application/octet-stream
+          files: |
+            SW4STM/Debug/canfilter.hex
+            SW4STM/Debug/canfilter.elf
+          tag_name: build-${{ github.run_number }}

--- a/SW4STM/.mxproject
+++ b/SW4STM/.mxproject
@@ -1,7 +1,7 @@
 [PreviousGenFiles]
-HeaderPath=../../Inc
+HeaderPath=../Inc
 HeaderFiles=stm32f1xx_it.h;stm32f1xx_hal_conf.h;main.h;
-SourcePath=../../Src
+SourcePath=../Src
 SourceFiles=stm32f1xx_it.c;stm32f1xx_hal_msp.c;main.c;
 
 [PreviousLibFiles]

--- a/SW4STM/.mxproject
+++ b/SW4STM/.mxproject
@@ -1,7 +1,7 @@
 [PreviousGenFiles]
-HeaderPath=/home/eko/Schreibtisch/stlink/canfilter/Inc
+HeaderPath=../../Inc
 HeaderFiles=stm32f1xx_it.h;stm32f1xx_hal_conf.h;main.h;
-SourcePath=/home/eko/Schreibtisch/stlink/canfilter/Src
+SourcePath=../../Src
 SourceFiles=stm32f1xx_it.c;stm32f1xx_hal_msp.c;main.c;
 
 [PreviousLibFiles]

--- a/SW4STM/Debug/Drivers/STM32F1xx_HAL_Driver/Src/subdir.mk
+++ b/SW4STM/Debug/Drivers/STM32F1xx_HAL_Driver/Src/subdir.mk
@@ -54,7 +54,7 @@ Drivers/STM32F1xx_HAL_Driver/Src/%.o: ../Drivers/STM32F1xx_HAL_Driver/Src/%.c
 	@echo 'Building file: $<'
 	@echo 'Invoking: MCU GCC Compiler'
 	@echo $(PWD)
-	arm-none-eabi-gcc -mcpu=cortex-m3 -mthumb -mfloat-abi=soft -DUSE_HAL_DRIVER -DSTM32F105xC -I"../../Inc" -I"../../Drivers/STM32F1xx_HAL_Driver/Inc" -I"../../Drivers/STM32F1xx_HAL_Driver/Inc/Legacy" -I"../../Drivers/CMSIS/Device/ST/STM32F1xx/Include" -I"../../Drivers/CMSIS/Include"  -Og -g3 -Wall -fmessage-length=0 -ffunction-sections -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$@" -o "$@" "$<"
+	arm-none-eabi-gcc -mcpu=cortex-m3 -mthumb -mfloat-abi=soft -DUSE_HAL_DRIVER -DSTM32F105xC -I"../Inc" -I"../Drivers/STM32F1xx_HAL_Driver/Inc" -I"../Drivers/STM32F1xx_HAL_Driver/Inc/Legacy" -I"../Drivers/CMSIS/Device/ST/STM32F1xx/Include" -I"../Drivers/CMSIS/Include"  -Og -g3 -Wall -fmessage-length=0 -ffunction-sections -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$@" -o "$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' '
 

--- a/SW4STM/Debug/Drivers/STM32F1xx_HAL_Driver/Src/subdir.mk
+++ b/SW4STM/Debug/Drivers/STM32F1xx_HAL_Driver/Src/subdir.mk
@@ -54,7 +54,7 @@ Drivers/STM32F1xx_HAL_Driver/Src/%.o: ../Drivers/STM32F1xx_HAL_Driver/Src/%.c
 	@echo 'Building file: $<'
 	@echo 'Invoking: MCU GCC Compiler'
 	@echo $(PWD)
-	arm-none-eabi-gcc -mcpu=cortex-m3 -mthumb -mfloat-abi=soft -DUSE_HAL_DRIVER -DSTM32F105xC -I"/home/eko/Schreibtisch/stlink/canfilter/Inc" -I"/home/eko/Schreibtisch/stlink/canfilter/Drivers/STM32F1xx_HAL_Driver/Inc" -I"/home/eko/Schreibtisch/stlink/canfilter/Drivers/STM32F1xx_HAL_Driver/Inc/Legacy" -I"/home/eko/Schreibtisch/stlink/canfilter/Drivers/CMSIS/Device/ST/STM32F1xx/Include" -I"/home/eko/Schreibtisch/stlink/canfilter/Drivers/CMSIS/Include"  -Og -g3 -Wall -fmessage-length=0 -ffunction-sections -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$@" -o "$@" "$<"
+	arm-none-eabi-gcc -mcpu=cortex-m3 -mthumb -mfloat-abi=soft -DUSE_HAL_DRIVER -DSTM32F105xC -I"../../Inc" -I"../../Drivers/STM32F1xx_HAL_Driver/Inc" -I"../../Drivers/STM32F1xx_HAL_Driver/Inc/Legacy" -I"../../Drivers/CMSIS/Device/ST/STM32F1xx/Include" -I"../../Drivers/CMSIS/Include"  -Og -g3 -Wall -fmessage-length=0 -ffunction-sections -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$@" -o "$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' '
 

--- a/SW4STM/Debug/Src/subdir.mk
+++ b/SW4STM/Debug/Src/subdir.mk
@@ -30,7 +30,7 @@ Src/%.o: ../Src/%.c
 	@echo 'Building file: $<'
 	@echo 'Invoking: MCU GCC Compiler'
 	@echo $(PWD)
-	arm-none-eabi-gcc -mcpu=cortex-m3 -mthumb -mfloat-abi=soft -DUSE_HAL_DRIVER -DSTM32F105xC -I"../../Inc" -I"../../Drivers/STM32F1xx_HAL_Driver/Inc" -I"../../Drivers/STM32F1xx_HAL_Driver/Inc/Legacy" -I"../../Drivers/CMSIS/Device/ST/STM32F1xx/Include" -I"../../Drivers/CMSIS/Include"  -Og -g3 -Wall -fmessage-length=0 -ffunction-sections -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$@" -o "$@" "$<"
+	arm-none-eabi-gcc -mcpu=cortex-m3 -mthumb -mfloat-abi=soft -DUSE_HAL_DRIVER -DSTM32F105xC -I"../Inc" -I"../Drivers/STM32F1xx_HAL_Driver/Inc" -I"../Drivers/STM32F1xx_HAL_Driver/Inc/Legacy" -I"../Drivers/CMSIS/Device/ST/STM32F1xx/Include" -I"../Drivers/CMSIS/Include"  -Og -g3 -Wall -fmessage-length=0 -ffunction-sections -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$@" -o "$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' '
 

--- a/SW4STM/Debug/Src/subdir.mk
+++ b/SW4STM/Debug/Src/subdir.mk
@@ -30,7 +30,7 @@ Src/%.o: ../Src/%.c
 	@echo 'Building file: $<'
 	@echo 'Invoking: MCU GCC Compiler'
 	@echo $(PWD)
-	arm-none-eabi-gcc -mcpu=cortex-m3 -mthumb -mfloat-abi=soft -DUSE_HAL_DRIVER -DSTM32F105xC -I"/home/eko/Schreibtisch/stlink/canfilter/Inc" -I"/home/eko/Schreibtisch/stlink/canfilter/Drivers/STM32F1xx_HAL_Driver/Inc" -I"/home/eko/Schreibtisch/stlink/canfilter/Drivers/STM32F1xx_HAL_Driver/Inc/Legacy" -I"/home/eko/Schreibtisch/stlink/canfilter/Drivers/CMSIS/Device/ST/STM32F1xx/Include" -I"/home/eko/Schreibtisch/stlink/canfilter/Drivers/CMSIS/Include"  -Og -g3 -Wall -fmessage-length=0 -ffunction-sections -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$@" -o "$@" "$<"
+	arm-none-eabi-gcc -mcpu=cortex-m3 -mthumb -mfloat-abi=soft -DUSE_HAL_DRIVER -DSTM32F105xC -I"../../Inc" -I"../../Drivers/STM32F1xx_HAL_Driver/Inc" -I"../../Drivers/STM32F1xx_HAL_Driver/Inc/Legacy" -I"../../Drivers/CMSIS/Device/ST/STM32F1xx/Include" -I"../../Drivers/CMSIS/Include"  -Og -g3 -Wall -fmessage-length=0 -ffunction-sections -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$@" -o "$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' '
 


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow that automates the process of building the firmware and creating a GitHub release.

The workflow is triggered on every push to the `master` branch and performs the following steps:
- Checks out the repository.
- Installs the ARM GCC toolchain.
- Builds the firmware using the makefile in `SW4STM/Debug`.
- Creates a new GitHub release.
- Uploads the `canfilter.hex` and `canfilter.elf` firmware files as release assets.